### PR TITLE
Fix missing NextResponse import

### DIFF
--- a/app/api/cancel/route.js
+++ b/app/api/cancel/route.js
@@ -1,5 +1,6 @@
 // /api/cancel
 import Airtable from 'airtable'
+import { NextResponse } from 'next/server'
 
 const base = new Airtable({ apiKey: process.env.AIRTABLE_CRM_API_KEY }).base(process.env.AIRTABLE_BASE)
 


### PR DESCRIPTION
## Summary
- import `NextResponse` in the cancel API route

## Testing
- `npx --yes next lint` *(fails: ERR_MODULE_NOT_FOUND)*

------
https://chatgpt.com/codex/tasks/task_e_68415250256c8324b8bd1826529a60e2