### PR TITLE
Fix Airtable env variable names

### DIFF
--- a/lib/airtable/saveRDV.js
+++ b/lib/airtable/saveRDV.js
@@ -3,9 +3,9 @@
 import Airtable from 'airtable'
 
 const base = new Airtable({ apiKey: process.env.AIRTABLE_CRM_API_KEY })
-  .base(process.env.AIRTABLE_BASE_ID)
+  .base(process.env.AIRTABLE_CRM_BASE_ID)
 
-const tableName = process.env.AIRTABLE_TABLE_NAME || 'RDV'  // ou votre table
+const tableName = process.env.AIRTABLE_CRM_TABLE_NAME || 'RDV'  // ou votre table
 
 /**
  * Enregistre un nouveau RDV dans Airtable.


### PR DESCRIPTION
## Summary
- update `saveRDV` to use `AIRTABLE_CRM_BASE_ID` and `AIRTABLE_CRM_TABLE_NAME`

## Testing
- `npm test` *(fails: Missing script)*
- `npm run lint` *(fails: `next` not found)*

------
https://chatgpt.com/codex/tasks/task_e_6841548429d483248328bf4c81a82e28