### PR TITLE
Use environment variable for Sentry DSN

### DIFF
--- a/instrumentation-client.js
+++ b/instrumentation-client.js
@@ -5,7 +5,7 @@
 import * as Sentry from "@sentry/nextjs";
 
 Sentry.init({
-  dsn: "https://97e8e9dc9987b892af1ee9c83d0058e6@o4509445135859712.ingest.de.sentry.io/4509445139267664",
+  dsn: process.env.SENTRY_DSN,
 
   // Add optional integrations for additional features
   integrations: [

--- a/readme/README.server.md
+++ b/readme/README.server.md
@@ -35,6 +35,7 @@ Alforis-V7.0/          # Répo local
   * `API_KEY` : Clé API de l’application
   * `NEXT_PUBLIC_API_URL` : URL back-end publique
   * `SSH_PRIVATE_KEY` : Clé privée SSH (déploiement VPS)
+  * `SENTRY_DSN` : URL de connexion Sentry
 
 ### 2. Vercel (Preview & Prod)
 
@@ -44,6 +45,7 @@ Alforis-V7.0/          # Répo local
 
   * `API_KEY`              (production)
   * `NEXT_PUBLIC_API_URL`  (production)
+  * `SENTRY_DSN`           (production)
 
 ---
 
@@ -82,10 +84,11 @@ Alforis-V7.0/          # Répo local
 3. **Variables d’environnement** :
 
    ```bash
-   cat << 'EOF' > .env.local
-   API_KEY=ta_cle
-   NEXT_PUBLIC_API_URL=https://api.alforis.fr
-   EOF
+  cat << 'EOF' > .env.local
+  API_KEY=ta_cle
+  NEXT_PUBLIC_API_URL=https://api.alforis.fr
+  SENTRY_DSN=your_sentry_dsn
+  EOF
    ```
 4. **Build + Démarrage** :
 

--- a/sentry.edge.config.js
+++ b/sentry.edge.config.js
@@ -6,7 +6,7 @@
 import * as Sentry from "@sentry/nextjs";
 
 Sentry.init({
-  dsn: "https://97e8e9dc9987b892af1ee9c83d0058e6@o4509445135859712.ingest.de.sentry.io/4509445139267664",
+  dsn: process.env.SENTRY_DSN,
 
   // Define how likely traces are sampled. Adjust this value in production, or use tracesSampler for greater control.
   tracesSampleRate: 1,

--- a/sentry.server.config.js
+++ b/sentry.server.config.js
@@ -5,7 +5,7 @@
 import * as Sentry from "@sentry/nextjs";
 
 Sentry.init({
-  dsn: "https://97e8e9dc9987b892af1ee9c83d0058e6@o4509445135859712.ingest.de.sentry.io/4509445139267664",
+  dsn: process.env.SENTRY_DSN,
 
   // Define how likely traces are sampled. Adjust this value in production, or use tracesSampler for greater control.
   tracesSampleRate: 1,


### PR DESCRIPTION
## Summary
- reference `SENTRY_DSN` variable for Sentry initialization
- document `SENTRY_DSN` setup in server README

## Testing
- `npm ci --ignore-scripts` *(fails: Invalid Version)*

------
https://chatgpt.com/codex/tasks/task_e_68417700851c83249642e9bf018d083a