### PR TITLE
Add Jest setup with basic test

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,0 +1,15 @@
+name: Node.js CI
+
+on:
+  pull_request:
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 22
+      - run: npm ci --legacy-peer-deps || npm install --legacy-peer-deps
+      - run: npm test

--- a/__tests__/hello.test.jsx
+++ b/__tests__/hello.test.jsx
@@ -1,0 +1,11 @@
+import { render, screen } from '@testing-library/react'
+import '@testing-library/jest-dom'
+
+function Hello() {
+  return <div>Hello World</div>
+}
+
+test('renders hello world', () => {
+  render(<Hello />)
+  expect(screen.getByText('Hello World')).toBeInTheDocument()
+})

--- a/jest.config.js
+++ b/jest.config.js
@@ -1,0 +1,10 @@
+const nextJest = require('next/jest')
+
+const createJestConfig = nextJest({ dir: './' })
+
+const customJestConfig = {
+  testEnvironment: 'jsdom',
+  setupFilesAfterEnv: ['<rootDir>/jest.setup.js'],
+}
+
+module.exports = createJestConfig(customJestConfig)

--- a/jest.setup.js
+++ b/jest.setup.js
@@ -1,0 +1,1 @@
+import '@testing-library/jest-dom'

--- a/package.json
+++ b/package.json
@@ -7,6 +7,7 @@
     "build": "next build",
     "start": "next start",
     "lint": "next lint",
+    "test": "jest",
     "devc": "./scripts/dev-clean.sh",
     "deploy": "scripts/deploy.sh",
     "postbuild": "next-sitemap",
@@ -66,7 +67,11 @@
     "lighthouse": "^12.6.1",
     "postcss": "^8.5.4",
     "tailwindcss": "^4.1.8",
-    "ts-prune": "^0.10.3"
+    "ts-prune": "^0.10.3",
+    "jest": "^29.7.0",
+    "@testing-library/react": "^14.2.1",
+    "@testing-library/jest-dom": "^6.4.2",
+    "@testing-library/user-event": "^14.4.3"
   },
   "main": "cookieconsent.esm.js",
   "directories": {


### PR DESCRIPTION
## Summary
- add npm test script
- install Jest and React Testing Library
- configure Jest with next/jest
- include basic `Hello` component test
- run tests in CI on pull requests

## Testing
- `npm test --silent` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_6841773621608324a5e139b351ca52aa